### PR TITLE
Bugfixes & improvements

### DIFF
--- a/includes/class-post-type.php
+++ b/includes/class-post-type.php
@@ -20,7 +20,7 @@ class WPAS_Ticket_Post_Type {
 	protected static $instance = null;
 
 	public function __construct() {
-		add_action( 'after_setup_theme',     array( $this, 'post_type' ),            10, 0 );
+		add_action( 'init',                  array( $this, 'post_type' ),            10, 0 );
 		add_action( 'init',                  array( $this, 'secondary_post_type' ),  10, 0 );
 		add_action( 'init',                  array( $this, 'register_post_status' ), 10, 0 );
 		add_action( 'post_updated_messages', array( $this, 'updated_messages' ),     10, 1 );    // Update the "post updated" messages for main post type

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -739,10 +739,12 @@ function wpas_update_ticket_status( $post_id, $status ) {
 		return false;
 	}
 
-	$updated = wp_update_post( array(
-		'ID'			=> $post_id,
-		'post_status'	=> $status
-	) );
+	$my_post = array(
+		'ID'          => $post_id,
+		'post_status' => $status
+	);
+
+	$updated = wp_update_post( $my_post );
 
 	if ( 0 !== intval( $updated ) ) {
 		wpas_log( $post_id, sprintf( __( 'Ticket state changed to &laquo;%s&raquo;', 'wpas' ), $custom_status[$status] ) );

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -739,12 +739,10 @@ function wpas_update_ticket_status( $post_id, $status ) {
 		return false;
 	}
 
-	$my_post = array(
-		'ID'          => $post_id,
-		'post_status' => $status
-	);
-
-	$updated = wp_update_post( $my_post );
+	$updated = wp_update_post( array(
+		'ID'			=> $post_id,
+		'post_status'	=> $status
+	) );
 
 	if ( 0 !== intval( $updated ) ) {
 		wpas_log( $post_id, sprintf( __( 'Ticket state changed to &laquo;%s&raquo;', 'wpas' ), $custom_status[$status] ) );

--- a/includes/functions-post.php
+++ b/includes/functions-post.php
@@ -733,17 +733,18 @@ function wpas_update_ticket_status( $post_id, $status ) {
 		return false;
 	}
 
-	global $wpdb;
+	$post = get_post( $post_id );
 
-	$updated = $wpdb->query(
-		$wpdb->prepare(
-			"UPDATE $wpdb->posts SET post_status = '%s' WHERE ID = '%d'",
-			$status,
-			$post_id
-		)
-	);
+	if( !$post || $post->post_status === $status ) {
+		return false;
+	}
 
-	if ( true === boolval( $updated ) ) {
+	$updated = wp_update_post( array(
+		'ID'			=> $post_id,
+		'post_status'	=> $status
+	) );
+
+	if ( 0 !== intval( $updated ) ) {
 		wpas_log( $post_id, sprintf( __( 'Ticket state changed to &laquo;%s&raquo;', 'wpas' ), $custom_status[$status] ) );
 	}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -125,17 +125,17 @@ function wpas_delete_taxonomy( $taxonomy ) {
 
 	global $wpdb;
 
-    $query = 'SELECT t.name, t.term_id
-            FROM ' . $wpdb->terms . ' AS t
-            INNER JOIN ' . $wpdb->term_taxonomy . ' AS tt
-            ON t.term_id = tt.term_id
-            WHERE tt.taxonomy = "' . $taxonomy . '"';
+	$query = 'SELECT t.name, t.term_id
+			FROM ' . $wpdb->terms . ' AS t
+			INNER JOIN ' . $wpdb->term_taxonomy . ' AS tt
+			ON t.term_id = tt.term_id
+			WHERE tt.taxonomy = "' . $taxonomy . '"';
 
-    $terms = $wpdb->get_results($query);
+	$terms = $wpdb->get_results($query);
 
-    foreach ( $terms as $term ) {
-        wp_delete_term( $term->term_id, $taxonomy );
-    }
+	foreach ( $terms as $term ) {
+		wp_delete_term( $term->term_id, $taxonomy );
+	}
 
 }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -123,11 +123,15 @@ function wpas_uninstall() {
  */
 function wpas_delete_taxonomy( $taxonomy ) {
 
-	$args = array(
-		'hide_empty' => false 
-	);
+	global $wpdb;
 
-	$terms = get_terms( $taxonomy, $args );
+    $query = 'SELECT t.name, t.term_id
+            FROM ' . $wpdb->terms . ' AS t
+            INNER JOIN ' . $wpdb->term_taxonomy . ' AS tt
+            ON t.term_id = tt.term_id
+            WHERE tt.taxonomy = "' . $taxonomy . '"';
+
+    $terms = $wpdb->get_results($query);
 
     foreach ( $terms as $term ) {
         wp_delete_term( $term->term_id, $taxonomy );

--- a/uninstall.php
+++ b/uninstall.php
@@ -123,15 +123,11 @@ function wpas_uninstall() {
  */
 function wpas_delete_taxonomy( $taxonomy ) {
 
-	global $wpdb;
+	$args = array(
+		'hide_empty' => false 
+	);
 
-    $query = 'SELECT t.name, t.term_id
-            FROM ' . $wpdb->terms . ' AS t
-            INNER JOIN ' . $wpdb->term_taxonomy . ' AS tt
-            ON t.term_id = tt.term_id
-            WHERE tt.taxonomy = "' . $taxonomy . '"';
-
-    $terms = $wpdb->get_results($query);
+	$terms = get_terms( $taxonomy, $args );
 
     foreach ( $terms as $term ) {
         wp_delete_term( $term->term_id, $taxonomy );


### PR DESCRIPTION
Some fixes & improvements:
- Use wp_update_post instead of wpdb->query
See also: https://codex.wordpress.org/Function_Reference/wp_update_post

- Fixed: php notices on single ticket page
Need to use the ```init``` hook instead of ```after_setup_theme```, otherwise you'll get on the single ticket page php notices like following:
```Notice: Trying to get property of non-object in
/wp-includes/query.php on line 3516```
```Notice: Trying to get property of non-object in /wp-includes/query.php
on line 3521```
```Notice: Trying to get property of non-object in /wp-includes/query.php
on line 3530```