### PR TITLE
fix initialization

### DIFF
--- a/class-awesome-support.php
+++ b/class-awesome-support.php
@@ -994,3 +994,13 @@ class Awesome_Support {
 	}
 
 }
+
+/**
+ * Main Awesome Support instance.
+ * @var Awesome_Support $awesome_support - instance of awesome support
+ * @since 3.1.7
+ */
+global $awesome_support;
+if ( ! $awesome_support ) {
+	$awesome_support = Awesome_Support::get_instance();
+}


### PR DESCRIPTION
After couple of hours, searching why the language resources were not loaded,
we found out that the wordpress hook "plugins_loaded" needs to be called twice to load the language resources for e.g. de_DE. 
So we dived deeper into the problem and found out that the instance of the class was created after "plugins_loaded" was triggered. 
To ensure that the "add_action" calls in the "__construct()" function is called before "plugins_loaded" is triggered we create a global instance. 