### PR TITLE
Fixed "PHP Notice:  Undefined index: wpas_after_reply"

### DIFF
--- a/includes/admin/class-admin-user.php
+++ b/includes/admin/class-admin-user.php
@@ -83,8 +83,11 @@ class WPAS_User {
 			return false;
 		}
 
-		update_user_meta( $user_id, 'wpas_after_reply', $_POST['wpas_after_reply'] );
+		$wpas_after_reply = filter_input( INPUT_POST, 'wpas_after_reply' );
 
+		if ( $wpas_after_reply ) {
+			update_user_meta( $user_id, 'wpas_after_reply', $wpas_after_reply );
+		}
 	}
 
 }


### PR DESCRIPTION
This commit fixes two small issues:

1. PHP Notice:  Undefined index: wpas_after_reply" when updating user profile on "Edit User" page:

PHP Notice:  Undefined index: wpas_after_reply in \wp\wp-content\plugins\awesome-support\includes\admin\class-admin-user.php on line 86
PHP Stack trace:
PHP   1. {main}() \wp\wp-admin\user-edit.php:0
PHP   2. do_action() \wp\wp-admin\user-edit.php:146
PHP   3. call_user_func_array() \wp\wp-includes\plugin.php:496
PHP   4. WPAS_User->save_user_custom_fields() \wp\wp-includes\plugin.php:496

2. Do not access superglobal $_POST Array directly